### PR TITLE
Add CI jobs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,42 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+
+jobs:
+  Docs:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install torch CPU-only version
+        run: python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Install charonload
+        run: python -m pip install --editable ".[dev]"
+
+      - name: Build docs
+        run: nox -s docs
+
+      - name: Deploy docs
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: build/docs/html
+          clean: true
+          single-commit: true
+        if: github.event_name != 'pull_request'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  lint:
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.8', '3.9', '3.10', '3.11']
+
+    name: "Python ${{ matrix.python }}"
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          cache: 'pip'
+
+      - name: Install torch CPU-only version
+        run: python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Install charonload
+        run: python -m pip install --editable ".[dev]"
+
+      - name: Run linters
+        run: nox -s lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,43 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-22.04', 'windows-2022']
+        python: ['3.8', '3.9', '3.10', '3.11']
+
+    name: "${{ matrix.os }} / Python ${{ matrix.python }}"
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          cache: 'pip'
+
+      - name: Install torch CPU-only version
+        run: python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Install charonload
+        run: python -m pip install --editable ".[dev]"
+
+      - name: Run tests
+        run: nox -s tests
+
+      - name: Run C++-only test
+        run: |
+          cmake -S tests/cpp_only_project -B build/cpp_only_project
+          cmake --build build/cpp_only_project --parallel


### PR DESCRIPTION
After the initial release of the code, we can now check it automatically. Set up respective CI jobs for this purpose.