### PR TITLE
Make CI more resource efficient

### DIFF
--- a/.github/torch_cpu_requirements.txt
+++ b/.github/torch_cpu_requirements.txt
@@ -1,0 +1,2 @@
+--index-url https://download.pytorch.org/whl/cpu
+torch

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,17 @@
 name: Docs
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
 
   pull_request:
     types: [opened, reopened, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -23,9 +28,10 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
+          cache-dependency-path: '**/*requirements.txt'
 
       - name: Install torch CPU-only version
-        run: python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+        run: python -m pip install -r .github/torch_cpu_requirements.txt
 
       - name: Install charonload
         run: python -m pip install --editable ".[dev]"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     strategy:
@@ -26,9 +30,10 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           cache: 'pip'
+          cache-dependency-path: '**/*requirements.txt'
 
       - name: Install torch CPU-only version
-        run: python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+        run: python -m pip install -r .github/torch_cpu_requirements.txt
 
       - name: Install charonload
         run: python -m pip install --editable ".[dev]"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     strategy:
@@ -27,9 +31,10 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           cache: 'pip'
+          cache-dependency-path: '**/*requirements.txt'
 
       - name: Install torch CPU-only version
-        run: python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+        run: python -m pip install -r .github/torch_cpu_requirements.txt
 
       - name: Install charonload
         run: python -m pip install --editable ".[dev]"


### PR DESCRIPTION
Currently, the CI always downloads torch from scratch and continues to run after updating a PR which wastes resources and results in delayed feedback when hotfixes are shortly pushed. Improve the caching and enable cancelling old jobs to improve upon on this.