### PR TITLE
Update badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,32 @@
 <!---
 <p align="center">
 -->
-<img alt="Python" src="https://img.shields.io/badge/python-3.8%2B-blue"/>
+<a href="https://pypi.python.org/pypi/charonload">
+    <img alt="PyPI - Version" src="https://img.shields.io/pypi/v/charonload">
+</a>
+<a href="https://pypi.python.org/pypi/charonload">
+    <img alt="PyPI - Python Version" src="https://img.shields.io/pypi/pyversions/charonload">
+</a>
+<a href="https://github.com/vc-bonn/charonload/blob/main/LICENSE">
+    <img alt="GitHub License" src="https://img.shields.io/github/license/vc-bonn/charonload"/>
+</a>
+<a href="https://github.com/vc-bonn/charonload/actions/workflows/tests.yml">
+    <img alt="Tests" src="https://github.com/vc-bonn/charonload/actions/workflows/tests.yml/badge.svg">
+</a>
+<a href="https://github.com/vc-bonn/charonload/actions/workflows/lint.yml">
+    <img alt="Lint" src="https://github.com/vc-bonn/charonload/actions/workflows/lint.yml/badge.svg">
+</a>
+<a href="https://vc-bonn.github.io/charonload">
+    <img alt="Documentation" src="https://img.shields.io/badge/docs-Latest-green.svg"/>
+</a>
 <a href="https://github.com/psf/black">
     <img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"/>
 </a>
-<a href="https://numpydoc.readthedocs.io/en/latest/format.html">
-    <img alt="Style: numpy" src="https://img.shields.io/badge/%20style-numpy-459db9.svg"/>
-</a>
 <a href="https://github.com/astral-sh/ruff">
     <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Ruff" style="max-width:100%;">
+</a>
+<a href="https://mypy-lang.org">
+    <img alt="Checked with mypy" src="https://www.mypy-lang.org/static/mypy_badge.svg">
 </a>
 <!---
 </p>


### PR DESCRIPTION
The initial set of badges in the README do not display all relevant information. Add more of them to show the project's status more faithfully.

The PyPI badges are also included to prepare for the upcoming release and upload.