### PR TITLE
Add CI job for changelog preparation

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,45 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+template: |
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
+categories:
+  - title: Added
+    labels:
+      - added
+  - title: Changed
+    labels:
+      - changed
+  - title: Deprecated
+    labels:
+      - deprecated
+  - title: Removed
+    labels:
+      - removed
+  - title: Fixed
+    labels:
+      - fixed
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+
+version-resolver:
+  major:
+    labels:
+      - major
+  minor:
+    labels:
+      - minor
+  patch:
+    labels:
+      - patch
+  default: patch
+
+include-labels:
+  - 'added'
+  - 'changed'
+  - 'deprecated'
+  - 'removed'
+  - 'fixed'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,25 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  Update:
+    permissions:
+      contents: write
+      pull-requests: read
+
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+          disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In order to communicate the changes of a new release, an informative and concise changelog should be written. In order to facilitate this, add a respective CI job that automatically accumulates all labeled PRs in a draft log.