### PR TITLE
Add CI job for PyPI upload

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,71 @@
+name: PyPi
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+  release:
+    types:
+      - published
+
+jobs:
+  dist:
+    name: Distribution build
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hynek/build-and-inspect-python-package@v2
+
+  publish-test:
+    name: Upload release to TestPyPI
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    needs:
+      - dist
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/charonload
+
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    needs:
+      - publish-test
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/charonload
+
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-All notable changes to this project will be documented in this file. 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - YYYY-MM-DD
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 graft src/charonload/cmake
 include src/charonload/py.typed
 exclude CMakeLists.txt
+prune tests


### PR DESCRIPTION
To prepare for the upcoming release, we also need a respective workflow for publishing our package. Add a respective CI job that builds the package at each commit but only uploads when a release is created.