### PR TITLE
Add internal release guide

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -5,6 +5,16 @@ template: |
 
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
 
+  ---
+
+  ### Release Guide
+
+  1. Bump version in `pyproject.toml`
+  2. Update corresponding CMake version by calling `tools/create_cmake_version_file.py`
+  3. Update `CHANGELOG.md` with notes from release draft and header with version and release date
+  4. Open a PR with the above changes and merge it
+  5. Release the version by editing the draft
+
 categories:
   - title: Added
     labels:


### PR DESCRIPTION
In order to ensure smooth releases, some important aspects have to be considered which might not all be obvious and specific to the charonload project. Add a respective guide in the release drafter to document the required steps.