### PR TITLE
Render license metadata correctly on PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ name = "charonload"
 version = "0.1.0"
 authors = [{ name = "Patrick Stotko", email = "stotko@cs.uni-bonn.de" }]
 description = "Develop C++/CUDA extensions with PyTorch like Python scripts"
-license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [


### PR DESCRIPTION
The license metadata of charonload on PyPI renders the license twice: 1. according to the classifier, 2. by copying the license text from the LICENSE file. Avoid this duplicate rendering by only specifying the license in the classifier, as recommended in the [Python Packaging User Guide](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license).