### PR TITLE
Enforce modern | notation for unions in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,7 @@ autodoc_default_options = {
 docstring_default_arg_substitution = "*Default*: "
 autodoc_preserve_defaults = True
 
-simplify_optional_unions = False
+always_use_bars_union = True
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dev = [
     "sphinx",
     "furo",
     "sphinx-autobuild",
-    "sphinx-autodoc-typehints",
+    "sphinx-autodoc-typehints>=2.0",
     "sphinx_autodoc_defaultargs",
     "sphinx_copybutton",
     "sphinx_design",


### PR DESCRIPTION
The recent update of sphinx-autodoc-typehints allows to enforce using the modern `|` notation for over the more verbose `Union[...]`. Bump our requirements to that version and enable the respective option.