### PR TITLE
Fix CMake error with CUDA_ARCHITECTURES and old policy scope

### DIFF
--- a/src/charonload/cmake/charonload-config.cmake
+++ b/src/charonload/cmake/charonload-config.cmake
@@ -25,7 +25,9 @@ get_filename_component(PACKAGE_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}/../" ABSOLU
 if(CMAKE_VERSION VERSION_LESS 3.27)
     message(FATAL_ERROR "CharonLoad requires CMake 3.27+ but older version ${CMAKE_VERSION} is used instead!")
 endif()
-cmake_policy(VERSION 3.27)
+
+# Required for charonload_detect_torch_cxx_standard()
+cmake_policy(SET CMP0137 NEW)
 
 
 macro(charonload_message)

--- a/tests/data/torch_cmake_old_policy_cuda/CMakeLists.txt
+++ b/tests/data/torch_cmake_old_policy_cuda/CMakeLists.txt
@@ -1,12 +1,12 @@
 # Oldest policy version without deprecation warning for CMake 3.27
 cmake_minimum_required(VERSION 3.5)
 
-project(torch_cmake_old_policy LANGUAGES CXX)
+project(torch_cmake_old_policy_cuda LANGUAGES CXX CUDA)
 
 find_package(charonload)
 
 if(charonload_FOUND)
     charonload_add_torch_library(${TORCH_EXTENSION_NAME} MODULE)
 
-    target_sources(${TORCH_EXTENSION_NAME} PRIVATE bindings.cpp two_times_cpu.cpp)
+    target_sources(${TORCH_EXTENSION_NAME} PRIVATE bindings.cpp two_times_cuda.cu)
 endif()

--- a/tests/data/torch_cmake_old_policy_cuda/bindings.cpp
+++ b/tests/data/torch_cmake_old_policy_cuda/bindings.cpp
@@ -1,0 +1,26 @@
+#include <torch/python.h>
+
+#include "two_times_cuda.h"
+
+using namespace pybind11::literals;
+
+#define STRINGIFY_IMPL(x) #x
+#define STRINGIFY(a) STRINGIFY_IMPL(a)
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    m.doc() = "A C++/CUDA extension module named \"" STRINGIFY(TORCH_EXTENSION_NAME) "\" that is built just-in-time.";
+
+    m.def("two_times", &two_times, "input"_a, R"(
+        Multiply the given input tensor by a factor of 2 on the GPU using CUDA.
+
+        Parameters
+        ----------
+        input
+            A tensor with arbitrary shape and dtype.
+
+        Returns
+        -------
+        A new tensor with the same shape and dtype as ``input`` and where each value is multiplied by 2.
+    )");
+}

--- a/tests/data/torch_cmake_old_policy_cuda/two_times_cuda.cu
+++ b/tests/data/torch_cmake_old_policy_cuda/two_times_cuda.cu
@@ -1,0 +1,33 @@
+#include <ATen/Dispatch.h>
+#include <ATen/ops/zeros_like.h>
+#include <c10/cuda/CUDAException.h>
+
+template <class T>
+__global__ void
+two_times_kernel(const T* const input, T* const output, const std::size_t N)
+{
+    for (int i = blockDim.x * blockIdx.x + threadIdx.x; i < N; i += blockDim.x * gridDim.x)
+    {
+        output[i] = T(2) * input[i];
+    }
+}
+
+at::Tensor
+two_times(const at::Tensor& input)
+{
+    auto output = at::zeros_like(input);
+
+    AT_DISPATCH_ALL_TYPES(input.scalar_type(),
+                          "two_times_cuda",
+                          [&]()
+                          {
+                              const std::uint32_t block_size = 128;
+                              const std::uint32_t num_blocks = (input.numel() + block_size - 1) / block_size;
+                              two_times_kernel<<<num_blocks, block_size>>>(input.data_ptr<scalar_t>(),
+                                                                           output.data_ptr<scalar_t>(),
+                                                                           input.numel());
+                              C10_CUDA_KERNEL_LAUNCH_CHECK();
+                          });
+
+    return output;
+}

--- a/tests/data/torch_cmake_old_policy_cuda/two_times_cuda.h
+++ b/tests/data/torch_cmake_old_policy_cuda/two_times_cuda.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <ATen/core/Tensor.h>
+
+at::Tensor
+two_times(const at::Tensor& input);

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -443,6 +443,27 @@ def test_torch_cmake_old_policy(shared_datadir: pathlib.Path, tmp_path: pathlib.
     assert torch.equal(t_output, 2 * t_input)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_torch_cmake_old_policy_cuda(shared_datadir: pathlib.Path, tmp_path: pathlib.Path) -> None:
+    project_directory = shared_datadir / "torch_cmake_old_policy_cuda"
+    build_directory = tmp_path / "build"
+
+    charonload.module_config["test_torch_cmake_old_policy_cuda"] = charonload.Config(
+        project_directory,
+        build_directory,
+        stubs_directory=VSCODE_STUBS_DIRECTORY,
+    )
+
+    import test_torch_cmake_old_policy_cuda as test_torch
+
+    t_input = torch.randint(0, 10, size=(3, 3, 3), dtype=torch.float, device="cuda")
+    t_output = test_torch.two_times(t_input)
+
+    assert t_output.device == t_input.device
+    assert t_output.shape == t_input.shape
+    assert torch.equal(t_output, 2 * t_input)
+
+
 def test_torch_clean_build(shared_datadir: pathlib.Path, tmp_path: pathlib.Path) -> None:
     project_directory = shared_datadir / "torch_cpu"
     build_directory = tmp_path / "build"


### PR DESCRIPTION
While detecting the C++ standard of Torch, we need to propagate all relevant platform variables to the test program which, in turn, requires to enable [CMake policy 0137](https://cmake.org/cmake/help/v3.24/policy/CMP0137.html). Since we enable all policies up to version 3.27, this however conflicts with [CMake policy 0104](https://cmake.org/cmake/help/v3.18/policy/CMP0104.html) which causes an error when the CUDA language is enabled before calling charonload. Reduce the number of changed policies to only the one that we actually rely on to fix this issue.