### PR TITLE
Fix date in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.1.1] - 2024-02-24
+## [0.1.1] - 2024-02-21
 
 ### Added
 


### PR DESCRIPTION
The date of the v0.1.1 release in the changelog accidentally refers to the wrong day.