### PR TITLE
Add helper script for changelog processing

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -12,8 +12,9 @@ template: |
   1. Bump version in `pyproject.toml`
   2. Update corresponding CMake version by calling `tools/create_cmake_version_file.py`
   3. Update `CHANGELOG.md` with notes from release draft and header with version and release date
-  4. Open a PR with the above changes and merge it
-  5. Release the version by editing the draft
+  4. Process links in `CHANGELOG.md` and check release date by calling `tools/process_changelog.py`
+  5. Open a PR with the above changes and merge it
+  6. Release the version by editing the draft
 
 categories:
   - title: Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,10 +147,15 @@ typing-modules = ["charonload._compat.typing"]
     "INP",  # flake8-no-pep420
     "ERA",  # eradicate
 ]
+"tools/*.py" = [
+    "D",   # pydocstyle
+    "INP", # flake8-no-pep420
+]
 "tools/create_cmake_version_file.py" = [
-    "D",    # pydocstyle
-    "INP",  # flake8-no-pep420
     "S603", # subprocess-without-shell-equals-true
+]
+"tools/process_changelog.py" = [
+    "S310", # suspicious-url-open-usage
 ]
 "noxfile.py" = [
     "D100", # undocumented-public-module

--- a/tools/process_changelog.py
+++ b/tools/process_changelog.py
@@ -1,0 +1,65 @@
+import datetime
+import pathlib
+import re
+import urllib.error
+import urllib.request
+
+
+def _markdown_link(url: str, text: str, fallback: str) -> str:
+    try:
+        url_valid_code = 200
+        url_valid = urllib.request.urlopen(url).getcode() == url_valid_code
+    except (urllib.error.HTTPError, urllib.error.URLError):
+        url_valid = False
+
+    if not url_valid:
+        print(f'Expanded link "{url}" unreachable. Skip modifying.')  # noqa: T201
+        return fallback
+
+    return f"[{text}]({url})"
+
+
+def github_pr(match: re.Match[str]) -> str:
+    link = _markdown_link(
+        url=f"https://github.com/vc-bonn/charonload/pull/{match.group(2)}",
+        text=f"\\{match.group(1)}",
+        fallback=f"{match.group(1)}",
+    )
+    return f"({link})"
+
+
+def github_user(match: re.Match[str]) -> str:
+    link = _markdown_link(
+        url=f"https://github.com/{match.group(2)}",
+        text=f"{match.group(1)}",
+        fallback=f"{match.group(1)}",
+    )
+    return f" {link}"
+
+
+def main() -> None:
+    project_root_dir = pathlib.Path(__file__).parents[1]
+    filename = project_root_dir / "CHANGELOG.md"
+
+    with filename.open("r") as f:
+        content = f.read()
+
+    # Update links
+    content = re.sub(pattern=R"\((#([0-9]+))\)", repl=github_pr, string=content)
+    content = re.sub(pattern=R" (@([a-zA-Z0-9-]{0,37}[a-zA-Z0-9]))", repl=github_user, string=content)
+
+    # Check date
+    dates = re.findall(pattern=R"[0-9]{4}-[0-9]{2}-[0-9]{2}", string=content)
+    timezone = datetime.timezone.utc
+    today = datetime.datetime.now(timezone).date().isoformat()
+    if not any(d == today for d in dates):
+        msg = f"Did not find dates matching today.\n  Dates: {dates}\n  Today ({timezone}): {today}"
+        raise ValueError(msg)
+
+    with filename.open("w") as f:
+        f.write(content)
+        print(f'Updated "{filename}"')  # noqa: T201
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Preparing the changelog for a release requires to include proper Markdown links for the PRs and contributors and to insert the date of the new version. Since this process is quite tedious and prone to subtle errors, add a helper script to take care of this and to also check if the updated links and the date are correct.