### PR TITLE
Perform clean only for incompatible versions

### DIFF
--- a/src/charonload/_finder.py
+++ b/src/charonload/_finder.py
@@ -31,7 +31,7 @@ from ._persistence import (
     _StrSerializer,
 )
 from ._runner import _run, _run_if, _StepStatus
-from ._version import _version
+from ._version import _is_compatible, _version
 
 colorama.just_fix_windows_console()
 
@@ -160,7 +160,11 @@ class _CleanStep(_JITCompileStep):
         }
         should_clean = [clean_if_failed[step] and failed for step, failed in step_failed.items()]
 
-        if self.config.clean_build or self.cache.get("version", _version()) != _version() or any(should_clean):
+        if (
+            self.config.clean_build
+            or not _is_compatible(self.cache.get("version", _version()), _version())
+            or any(should_clean)
+        ):
             for file in sorted(self.config.full_build_directory.rglob("*"), reverse=True):
                 if any(file.samefile(f) for f in [self.config.full_build_directory / "charonload" / "build.lock"]):
                     continue

--- a/src/charonload/_version.py
+++ b/src/charonload/_version.py
@@ -1,5 +1,22 @@
+from __future__ import annotations
+
 import importlib.metadata
+from typing import Tuple, cast
 
 
 def _version() -> str:
     return importlib.metadata.version(__package__)
+
+
+def _is_compatible(ver1: str, ver2: str) -> bool:
+    return _same_minor_version(_str_to_tuple(ver1), _str_to_tuple(ver2))
+
+
+def _str_to_tuple(ver: str) -> tuple[int, int, int]:
+    components = list(map(int, ver.split(".")))
+    components = [*components, 0, 0][:3]
+    return cast(Tuple[int, int, int], tuple(components))  # typing.Tuple required for Python 3.8
+
+
+def _same_minor_version(ver1: tuple[int, int, int], ver2: tuple[int, int, int]) -> bool:
+    return ver1[0] == ver2[0] and ver1[1] == ver2[1]


### PR DESCRIPTION
Currently, the build directory is always cleaned when the version of charonload used for that previous run differs from the current one. New versions, however, often include fully backwards-compatible changes such that cleaning  is not necessary in these cases. Follow the strategy specified in the CMake part, i.e. `SameMinorVersion`, as a measure to determine compatibility.