### PR TITLE
Avoid torch 2.3.0 in CI to workaround DLL import error

### DIFF
--- a/.github/torch_cpu_requirements.txt
+++ b/.github/torch_cpu_requirements.txt
@@ -1,2 +1,4 @@
 --index-url https://download.pytorch.org/whl/cpu
-torch
+# torch 2.3.0 on Windows may through a DLL import error, presumably due to the newly introduced dependency to MKL:
+# https://github.com/pytorch/pytorch/issues/125109
+torch!=2.3.0+cpu


### PR DESCRIPTION
The recently released torch version 2.3.0 seems to contain a bug causing DLL import errors on Windows. This is likely due to the MKL dependency introduced in this version. Workaround this issue in the CI by avoiding this particular version. On the user side, the version requirements are not yet restricted as this issue will be fixed in the upcoming version 2.3.1 and the bug only triggers on system installations of Python.