### PR TITLE
Log step progress in verbose mode

### DIFF
--- a/src/charonload/_runner.py
+++ b/src/charonload/_runner.py
@@ -253,7 +253,7 @@ def _run(
     if verbose:
         command = " ".join(command_args)
         print(  # noqa: T201
-            f"{colorama.Fore.GREEN}{colorama.Style.BRIGHT}Running: "
+            f"[charonload] {colorama.Fore.GREEN}{colorama.Style.BRIGHT}Running: "
             f'{colorama.Style.NORMAL}"{command}"{colorama.Style.RESET_ALL}'
         )
 


### PR DESCRIPTION
In verbose mode, the primary log is mostly generated by the executed commands (Configure, Build, Stub Generation steps). However, it is currently not obvious that more steps, e.g. a Clean step, are executed as well. Log each step when it starts to provide a summary of the current JIT compile progress.

In the future, the currently quite static log of steps could be shortened to indicate that steps were skipped. For this, the status and condition logic could become first-class behavior of a step which would come with the benefit of natively having a persistent state for each step.