### PR TITLE
Prefer default directories in config for installed projects

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install charonload
         run: python -m pip install --editable ".[dev]"
 
+      - name: Install test python project
+        run: python -m pip install tests/data/charonload_installed_project
+
       - name: Run tests
         run: nox -s tests
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ __pycache__/
 *.py[cod]
 build/
 dist/
-src/charonload.egg-info/
+*.egg-info/
 typings/
 
 # Documentation

--- a/tests/data/charonload_installed_project/MANIFEST.in
+++ b/tests/data/charonload_installed_project/MANIFEST.in
@@ -1,0 +1,1 @@
+graft src/charonload_installed_project/_C

--- a/tests/data/charonload_installed_project/pyproject.toml
+++ b/tests/data/charonload_installed_project/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "charonload_installed_project"
+version = "0.0.1"
+authors = [{ name = "Patrick Stotko", email = "stotko@cs.uni-bonn.de" }]
+description = "Dummy project for testing charonload"
+dependencies = ["torch", "numpy", "charonload"]
+
+
+[build-system]
+requires = ["setuptools>=64.0"]
+build-backend = "setuptools.build_meta"

--- a/tests/data/charonload_installed_project/src/charonload_installed_project/_C/CMakeLists.txt
+++ b/tests/data/charonload_installed_project/src/charonload_installed_project/_C/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.27)
+
+project(python_project LANGUAGES CXX)
+
+find_package(charonload)
+
+if(charonload_FOUND)
+    charonload_add_torch_library(${TORCH_EXTENSION_NAME} MODULE)
+
+    target_sources(${TORCH_EXTENSION_NAME} PRIVATE bindings.cpp two_times_cpu.cpp)
+endif()

--- a/tests/data/charonload_installed_project/src/charonload_installed_project/_C/bindings.cpp
+++ b/tests/data/charonload_installed_project/src/charonload_installed_project/_C/bindings.cpp
@@ -1,0 +1,26 @@
+#include <torch/python.h>
+
+#include "two_times_cpu.h"
+
+using namespace pybind11::literals;
+
+#define STRINGIFY_IMPL(x) #x
+#define STRINGIFY(a) STRINGIFY_IMPL(a)
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    m.doc() = "A C++/CUDA extension module named \"" STRINGIFY(TORCH_EXTENSION_NAME) "\" that is built just-in-time.";
+
+    m.def("two_times", &two_times, "input"_a, R"(
+        Multiply the given input tensor by a factor of 2 on the CPU.
+
+        Parameters
+        ----------
+        input
+            A tensor with arbitrary shape and dtype.
+
+        Returns
+        -------
+        A new tensor with the same shape and dtype as ``input`` and where each value is multiplied by 2.
+    )");
+}

--- a/tests/data/charonload_installed_project/src/charonload_installed_project/_C/two_times_cpu.cpp
+++ b/tests/data/charonload_installed_project/src/charonload_installed_project/_C/two_times_cpu.cpp
@@ -1,0 +1,22 @@
+#include "two_times_cpu.h"
+
+#include <ATen/Dispatch.h>
+#include <ATen/ops/zeros_like.h>
+
+at::Tensor
+two_times(const at::Tensor& input)
+{
+    auto output = at::zeros_like(input);
+
+    AT_DISPATCH_ALL_TYPES(input.scalar_type(),
+                          "two_times_cpu",
+                          [&]()
+                          {
+                              for (std::size_t i = 0; i < input.numel(); ++i)
+                              {
+                                  output.data_ptr<scalar_t>()[i] = scalar_t(2) * input.data_ptr<scalar_t>()[i];
+                              }
+                          });
+
+    return output;
+}

--- a/tests/data/charonload_installed_project/src/charonload_installed_project/_C/two_times_cpu.h
+++ b/tests/data/charonload_installed_project/src/charonload_installed_project/_C/two_times_cpu.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <ATen/core/Tensor.h>
+
+at::Tensor
+two_times(const at::Tensor& input);

--- a/tests/data/charonload_installed_project/src/charonload_installed_project/__init__.py
+++ b/tests/data/charonload_installed_project/src/charonload_installed_project/__init__.py
@@ -1,0 +1,16 @@
+import pathlib
+
+import charonload
+
+PROJECT_ROOT_DIRECTORY = pathlib.Path(__file__).parent
+
+
+charonload.module_config["_c_charonload_installed_project"] = charonload.Config(
+    pathlib.Path(__file__).parent / "_C",
+    build_directory=PROJECT_ROOT_DIRECTORY,  # Intentionally do in-source build
+    stubs_directory=PROJECT_ROOT_DIRECTORY,  # Similar to common in-source typings directory for VS Code
+    verbose=True,
+)
+
+
+from _c_charonload_installed_project import two_times  # noqa: E402, F401


### PR DESCRIPTION
If a Python project employing charonload gets installed along with the respective C++/CUDA code, the user-specified build and stub directories may now point into the Python installation directory. This could either lead to a confusing permission error or to pollution if JIT compilation succeeds. Catch these cases by falling back to the default directories.

In the future, we might consider handling these cases by generating and installing proper [PEP 561](https://peps.python.org/pep-0561/)-compatible (stub-only) packages.