### PR TITLE
Clean up unnecessary linter suppressions

### DIFF
--- a/.github/torch_cpu_requirements.txt
+++ b/.github/torch_cpu_requirements.txt
@@ -2,3 +2,6 @@
 # torch 2.3.0 on Windows may through a DLL import error, presumably due to the newly introduced dependency to MKL:
 # https://github.com/pytorch/pytorch/issues/125109
 torch!=2.3.0+cpu
+# numpy 2.0 on Windows may be incompatible to torch:
+# https://github.com/pytorch/pytorch/issues/128860
+numpy<2.0

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -636,7 +636,7 @@ def test_torch_clean_build_configure_failed(shared_datadir: pathlib.Path, tmp_pa
         stubs_directory=VSCODE_STUBS_DIRECTORY,
     )
 
-    import test_torch_clean_build_configure_failed as test_torch  # noqa: F811
+    import test_torch_clean_build_configure_failed as test_torch
 
     t_input = torch.randint(0, 10, size=(3, 3, 3), dtype=torch.float, device="cpu")
     t_output = test_torch.two_times(t_input)
@@ -1077,7 +1077,7 @@ def test_torch_broken_cmake_try_twice(shared_datadir: pathlib.Path, tmp_path: pa
     assert exc_info.type is charonload.CMakeConfigureError
 
     with pytest.raises(charonload.JITCompileError) as exc_info:
-        import test_torch_broken_cmake_try_twice  # noqa: F401, F811
+        import test_torch_broken_cmake_try_twice  # noqa: F401
 
     assert exc_info.type is charonload.CMakeConfigureError
 
@@ -1112,7 +1112,7 @@ def test_torch_broken_cpp_code_try_twice(shared_datadir: pathlib.Path, tmp_path:
     assert exc_info.type is charonload.BuildError
 
     with pytest.raises(charonload.JITCompileError) as exc_info:
-        import test_torch_broken_cpp_code_try_twice  # noqa: F401, F811
+        import test_torch_broken_cpp_code_try_twice  # noqa: F401
 
     assert exc_info.type is charonload.BuildError
 


### PR DESCRIPTION
ruff 0.5.2 includes a fix for a false positive of warning F811. This affects the suppression applied in the tests which are now unused and will cause warnings on their own. Remove the offending ones to ensure a clean build.

Furthermore, include a workaround for numpy 2.0 being incompatible with torch on Windows.