### PR TITLE
Honor PATH variable on Windows for DLL search

### DIFF
--- a/src/charonload/cmake/torch/add_torch_library.cmake
+++ b/src/charonload/cmake/torch/add_torch_library.cmake
@@ -161,9 +161,7 @@ function(charonload_add_torch_library name)
             OUTPUT "${CMAKE_BINARY_DIR}/charonload/$<CONFIG>/location.txt"
             CONTENT "$<TARGET_FILE:${name}>")
 
-        file(GENERATE
-            OUTPUT "${CMAKE_BINARY_DIR}/charonload/$<CONFIG>/windows_dll_directories.txt"
-            CONTENT "$<TARGET_RUNTIME_DLL_DIRS:${name}>")
+        charonload_generate_windows_dll_directories(${name} "${CMAKE_BINARY_DIR}/charonload/$<CONFIG>/windows_dll_directories.txt")
     endif()
 endfunction()
 
@@ -223,4 +221,19 @@ function(charonload_patch_dependencies name patch_functions)
             list(POP_BACK CMAKE_MESSAGE_INDENT)
         endif()
     endif()
+endfunction()
+
+
+function(charonload_generate_windows_dll_directories name output_file)
+    list(APPEND WINDOWS_DLL_DIRS "$<TARGET_RUNTIME_DLL_DIRS:${name}>")
+
+    if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+        cmake_path(CONVERT "$ENV{PATH}" TO_CMAKE_PATH_LIST WINDOWS_PATHS NORMALIZE)
+        list(REMOVE_DUPLICATES WINDOWS_PATHS)
+        list(APPEND WINDOWS_DLL_DIRS ${WINDOWS_PATHS})
+    endif()
+
+    file(GENERATE
+         OUTPUT ${output_file}
+         CONTENT "${WINDOWS_DLL_DIRS}")
 endfunction()

--- a/src/charonload/pybind11_stubgen/__main__.py
+++ b/src/charonload/pybind11_stubgen/__main__.py
@@ -16,8 +16,11 @@ def _make_importable(full_extension_path: pathlib.Path, windows_dll_directories:
 
     if platform.system() == "Windows":
         dll_directory_list = windows_dll_directories.split(";")
-        for d in dll_directory_list:
-            os.add_dll_directory(d)  # type: ignore[attr-defined]
+        for d_str in dll_directory_list:
+            d = pathlib.Path(d_str)
+            if d.exists() and d.is_dir():
+                # No guard required here
+                os.add_dll_directory(d)  # type: ignore[attr-defined]
 
 
 def main() -> None:


### PR DESCRIPTION
On Windows, DLL directories are already detected by CMake to ensure that loading the compiled extension module works. However, projects may have dependencies whose DLL files and directories are not recognized this way, e.g. CUDA libraries imported as unknown libraries. Honor the hints in the PATH variable in such cases as those dependencies could intentionally make use of it as their primary detection mechanism.