### PR TITLE
Ignore relative paths in collected DLL directories

### DIFF
--- a/src/charonload/_finder.py
+++ b/src/charonload/_finder.py
@@ -423,7 +423,7 @@ class _ImportPathStep(_JITCompileStep):
             dll_directory_list = windows_dll_directories.split(";")
             for d_str in dll_directory_list:
                 d = pathlib.Path(d_str)
-                if d.exists() and d.is_dir():
+                if d.exists() and d.is_absolute() and d.is_dir():
                     _windows_dll_directories_guard.add(d)
 
 

--- a/src/charonload/pybind11_stubgen/__main__.py
+++ b/src/charonload/pybind11_stubgen/__main__.py
@@ -18,7 +18,7 @@ def _make_importable(full_extension_path: pathlib.Path, windows_dll_directories:
         dll_directory_list = windows_dll_directories.split(";")
         for d_str in dll_directory_list:
             d = pathlib.Path(d_str)
-            if d.exists() and d.is_dir():
+            if d.exists() and d.is_absolute() and d.is_dir():
                 # No guard required here
                 os.add_dll_directory(d)  # type: ignore[attr-defined]
 


### PR DESCRIPTION
When collecting the list of DLL directories for all potential dependencies on Windows, relative paths such as `.` may be part of them. However, these will raise an exception when they are passed to the DLL search paths via `os.add_dll_directory(...)`. Filter relative paths and ignore them as their corresponding absolute paths will not be reliable anyways due to the unpredictable base directory that is picked.