### PR TITLE
Adapt to changes of default values in docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           name: Docs HTML
           path: build/docs/html
+          include-hidden-files: true
 
   publish:
     name: Upload release to GitHub Pages


### PR DESCRIPTION
GitHub recently changed the default for including hidden files in a the `upload-artifact` action, see [this blog](https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/). Adapt to this change to avoid deployment issues in the future.