### PR TITLE
Consider all installations paths for exclusion

### DIFF
--- a/src/charonload/_config.py
+++ b/src/charonload/_config.py
@@ -7,6 +7,7 @@ import pathlib
 import re
 import site
 import sys
+import sysconfig
 import tempfile
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -218,8 +219,9 @@ class Config:
         return full_stubs_directory
 
     def _exclude_install_directories(self: Self, directory: pathlib.Path) -> pathlib.Path | None:
-        install_directories = [site.getusersitepackages()] if site.ENABLE_USER_SITE else []
-        install_directories.extend(site.getsitepackages())
+        install_directories = [site.getuserbase()] if site.ENABLE_USER_SITE else []
+        install_directories.extend(sysconfig.get_paths().values())
+        install_directories = list(set(install_directories))  # Remove duplicates
 
         return (
             directory

--- a/tests/data/charonload_installed_project/src/charonload_installed_project/__init__.py
+++ b/tests/data/charonload_installed_project/src/charonload_installed_project/__init__.py
@@ -2,13 +2,15 @@ import pathlib
 
 import charonload
 
-PROJECT_ROOT_DIRECTORY = pathlib.Path(__file__).parent
+PROJECT_ROOT_DIRECTORY = pathlib.Path(__file__).parents[2]
+
+VSCODE_STUBS_DIRECTORY = PROJECT_ROOT_DIRECTORY / "typings"
 
 
 charonload.module_config["_c_charonload_installed_project"] = charonload.Config(
     pathlib.Path(__file__).parent / "_C",
     build_directory=PROJECT_ROOT_DIRECTORY,  # Intentionally do in-source build
-    stubs_directory=PROJECT_ROOT_DIRECTORY,  # Similar to common in-source typings directory for VS Code
+    stubs_directory=VSCODE_STUBS_DIRECTORY,  # Common in-source typings directory for VS Code
     verbose=True,
 )
 


### PR DESCRIPTION
A fallback to the default directories if the project is located in the Python installation directory has been introduced in #33. However, the exclusion condition was restricted to the `site-packages`  subdirectory. Extend the respective list with all Python installation directories which will also cover the base directory.