### PR TITLE
Handle single file stubs in skip condition

### DIFF
--- a/src/charonload/_finder.py
+++ b/src/charonload/_finder.py
@@ -368,7 +368,10 @@ class _StubGenerationStep(_JITCompileStep):
                 and (
                     self.cache.get("status_stub_generation", _StepStatus.SKIPPED) == _StepStatus.FAILED
                     or new_checksum != old_checksum
-                    or not (self.config.full_stubs_directory / self.module_name).exists()
+                    or (
+                        not (self.config.full_stubs_directory / self.module_name).exists()
+                        and not (self.config.full_stubs_directory / f"{self.module_name}.pyi").exists()
+                    )
                 )
             ),
             command_args=[


### PR DESCRIPTION
For faster JIT compilations, stubs are only build if a change has been detected. This includes a check if the generated stub directory already exists. However, in case of a single module, the stub generation may only generate a single stub file rather than a directory. Extend the check to also cover this case and add respective tests.