### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,9 +27,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-          cache: 'pip'
-          cache-dependency-path: '**/*requirements.txt'
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: "**/*requirements.txt"
 
       - name: Install torch CPU-only version
         run: python -m pip install -r .github/torch_cpu_requirements.txt
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: re-actors/alls-green@release/v1
-      with:
-        allowed-skips: publish
-        jobs: ${{ toJSON(needs) }}
+      - uses: re-actors/alls-green@release/v1
+        with:
+          allowed-skips: publish
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python: ["3.9", "3.10", "3.11", "3.12"]
 
     name: "Python ${{ matrix.python }}"
     runs-on: ubuntu-22.04
@@ -29,8 +29,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-          cache: 'pip'
-          cache-dependency-path: '**/*requirements.txt'
+          cache: "pip"
+          cache-dependency-path: "**/*requirements.txt"
 
       - name: Install torch CPU-only version
         run: python -m pip install -r .github/torch_cpu_requirements.txt
@@ -51,6 +51,6 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: re-actors/alls-green@release/v1
-      with:
-        jobs: ${{ toJSON(needs) }}
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: re-actors/alls-green@release/v1
-      with:
-        allowed-skips: publish-test, publish
-        jobs: ${{ toJSON(needs) }}
+      - uses: re-actors/alls-green@release/v1
+        with:
+          allowed-skips: publish-test, publish
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-22.04', 'windows-2022']
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        os: ["ubuntu-22.04", "windows-2022"]
+        python: ["3.9", "3.10", "3.11", "3.12"]
 
     name: "${{ matrix.os }} / Python ${{ matrix.python }}"
     runs-on: ${{ matrix.os }}
@@ -30,8 +30,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-          cache: 'pip'
-          cache-dependency-path: '**/*requirements.txt'
+          cache: "pip"
+          cache-dependency-path: "**/*requirements.txt"
 
       - name: Install torch CPU-only version
         run: python -m pip install -r .github/torch_cpu_requirements.txt
@@ -60,6 +60,6 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: re-actors/alls-green@release/v1
-      with:
-        jobs: ${{ toJSON(needs) }}
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ CharonLoad reduces the burden to start writing and experimenting with custom GPU
 
 ## Installation
 
-CharonLoad requires **Python >=3.8** and can be installed from PyPI:
+CharonLoad requires **Python >=3.9** and can be installed from PyPI:
 
 ```sh
 pip install charonload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.4"
 authors = [{ name = "Patrick Stotko", email = "stotko@cs.uni-bonn.de" }]
 description = "Develop C++/CUDA extensions with PyTorch like Python scripts"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "cmake>=3.27",
     'ninja ; platform_system != "Windows"',
@@ -21,7 +21,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: C++",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -92,7 +91,7 @@ line-length = 120
 [tool.isort]
 profile = "black"
 multi_line_output = 3
-py_version = 38
+py_version = 39
 
 
 [tool.docformatter]

--- a/src/charonload/_runner.py
+++ b/src/charonload/_runner.py
@@ -10,13 +10,14 @@ import shutil
 import subprocess
 import sys
 from abc import ABC, abstractmethod
-from typing import IO, TYPE_CHECKING, Iterable, Iterator, Literal
+from typing import IO, TYPE_CHECKING, Literal
 
 import colorama
 
 from ._errors import CommandNotFoundError
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Iterable, Iterator
     from types import TracebackType
 
     from ._compat.typing import Self

--- a/src/charonload/_version.py
+++ b/src/charonload/_version.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import importlib.metadata
-from typing import Tuple, cast
+from typing import cast
 
 
 def _version() -> str:
@@ -15,7 +15,7 @@ def _is_compatible(ver1: str, ver2: str) -> bool:
 def _str_to_tuple(ver: str) -> tuple[int, int, int]:
     components = list(map(int, ver.split(".")))
     components = [*components, 0, 0][:3]
-    return cast(Tuple[int, int, int], tuple(components))  # typing.Tuple required for Python 3.8
+    return cast(tuple[int, int, int], tuple(components))
 
 
 def _same_minor_version(ver1: tuple[int, int, int], ver2: tuple[int, int, int]) -> bool:


### PR DESCRIPTION
Python 3.8 reached end of life on 2024-10-07 and will not be receive any upstream support anymore. Drop the support on our side as well to encourage users to upgrade to a more recent version.