### PR TITLE
Fix more warnings enabled from Scientific Python guide

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
     "clang-format~=14.0",
 
     # Linting
-    "ruff>=0.2",
+    "ruff>=0.6",
     "mypy",
     "codespell",
     "check-manifest",
@@ -104,7 +104,6 @@ syntax = "numpy"
 
 
 [tool.ruff]
-src = ["src"]
 line-length = 120
 output-format = "full"
 
@@ -185,10 +184,12 @@ show_missing = true
 
 
 [tool.mypy]
+strict = true
 plugins = ["numpy.typing.mypy_plugin"]
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 warn_return_any = true
 warn_unused_configs = true
+warn_unreachable = true
 pretty = true
 ignore_missing_imports = true                                                # This could be made local for the tests
 

--- a/src/charonload/_compat/hashlib.py
+++ b/src/charonload/_compat/hashlib.py
@@ -19,7 +19,7 @@ if sys.version_info < (3, 11):
         elif callable(digest):
             file_hasher = digest()
         else:
-            msg = "Wrong type of digest: Should be either str or Callable."
+            msg = "Wrong type of digest: Should be either str or Callable."  # type: ignore[unreachable]
             raise TypeError(msg)
 
         num_blocks = 1024

--- a/src/charonload/_finder.py
+++ b/src/charonload/_finder.py
@@ -40,7 +40,9 @@ colorama.just_fix_windows_console()
 class JITCompileFinder(importlib.abc.MetaPathFinder):
     """An import finder for executing the just-in-time (JIT) compilation."""
 
-    def find_spec(self: Self, fullname, path, target=None) -> None:  # noqa: ANN001, ARG002
+    def find_spec(  # type: ignore[no-untyped-def]
+        self: Self, fullname, path, target=None  # noqa: ANN001, ARG002
+    ) -> None:
         """
         Find the spec of the specified module.
 
@@ -96,7 +98,7 @@ class JITCompileFinder(importlib.abc.MetaPathFinder):
 
 def _load(module_name: str, config: ResolvedConfig) -> None:
     if not isinstance(config, ResolvedConfig):
-        msg = f"Invalid type of configuration: expected 'Config', but got '{config.__class__.__name__}'"
+        msg = f"Invalid type of configuration: expected 'Config', but got '{config.__class__.__name__}'"  # type: ignore[unreachable]
         raise TypeError(msg)
 
     (config.full_build_directory / "charonload").mkdir(parents=True, exist_ok=True)
@@ -500,7 +502,7 @@ class _OsAddDllDirectoryGuard:
     @staticmethod
     def _clear(directories: dict[pathlib.Path, Any]) -> None:
         for handler in directories.values():
-            handler.close()  # type: ignore[attr-defined]
+            handler.close()
 
 
 _windows_dll_directories: dict[pathlib.Path, Any] = {}

--- a/src/charonload/_persistence.py
+++ b/src/charonload/_persistence.py
@@ -53,7 +53,7 @@ class _Serializer:
     decode: Callable[[str], Any]
 
 
-class _PersistentDict(collections.abc.MutableMapping):
+class _PersistentDict(collections.abc.MutableMapping[str, Any]):
     def __init__(self: Self) -> None:
         self._entries: dict[str, _TypedPersistentString] = {}
         self._serializers: dict[type, _Serializer] = {}
@@ -76,7 +76,7 @@ class _PersistentDict(collections.abc.MutableMapping):
         msg = "Deleting connections is not supported."
         raise AttributeError(msg)
 
-    def __iter__(self: Self) -> collections.abc.Iterator:
+    def __iter__(self: Self) -> collections.abc.Iterator[str]:
         return iter(self._entries)
 
     def __len__(self: Self) -> int:

--- a/src/charonload/cmake/torch/add_torch_library.cmake
+++ b/src/charonload/cmake/torch/add_torch_library.cmake
@@ -26,7 +26,7 @@
             // Define some bindings ...
         }
 
-  3. The usage requirements for PyTorch will be added to ``<name>`` and, if necessary,
+  3. The :doc:`usage requirements for PyTorch</src/pytorch_handling>` will be added to ``<name>`` and, if necessary,
      recursively to all of its dependencies:
 
      - C++ standard

--- a/src/charonload/pybind11_stubgen/__main__.py
+++ b/src/charonload/pybind11_stubgen/__main__.py
@@ -46,7 +46,7 @@ def main() -> None:
     # Patch list of command line argument globally as this list cannot directly be passed to pybind11-stubgen
     sys.argv = [sys.argv[0], *original_args]
 
-    pybind11_stubgen.main()
+    pybind11_stubgen.main()  # type: ignore[no-untyped-call]
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -39,7 +39,7 @@ def test_installed_project() -> None:
     assert config.full_stubs_directory not in config.full_project_directory.parents
 
     t_input = torch.randint(0, 10, size=(3, 3, 3), dtype=torch.float, device="cpu")
-    t_output = charonload_installed_project.two_times(t_input)
+    t_output = charonload_installed_project.two_times(t_input)  # type: ignore[attr-defined]
 
     assert t_output.device == t_input.device
     assert t_output.shape == t_input.shape
@@ -399,7 +399,7 @@ def _torch_incremental_build(
     p.join()
     assert p.exitcode == 0
 
-    return float(result.value)  # type: ignore[attr-defined]
+    return float(result.value)
 
 
 def test_torch_incremental_build_cpp(shared_datadir: pathlib.Path, tmp_path: pathlib.Path) -> None:
@@ -1009,7 +1009,7 @@ def test_concurrent_process_fork_import(shared_datadir: pathlib.Path, tmp_path: 
 
     num = 5
     jobs = [
-        multiprocessing.get_context("fork").Process(target=_concurrent_process_fork_import, args=(i,))  # type: ignore[attr-defined]
+        multiprocessing.get_context("fork").Process(target=_concurrent_process_fork_import, args=(i,))
         for i in range(num)
     ]
 


### PR DESCRIPTION
Some time has passed after #5, it is time to revisit the recommendations from the Scientific Python guide again. Enable more rules and fix the outstanding warnings to more closely adhere to the guide.