### PR TITLE
Fix recent ruff linter warnings

### DIFF
--- a/src/charonload/__init__.py
+++ b/src/charonload/__init__.py
@@ -23,7 +23,7 @@ import sys
 required_version = (3, 8)
 
 if sys.version_info[:2] < required_version:  # pragma: no cover
-    msg = "%s requires Python %d.%d+" % (__package__, *required_version)
+    msg = "%s requires Python %d.%d+" % (__package__, *required_version)  # noqa: UP031
     raise RuntimeError(msg)
 
 del required_version
@@ -58,10 +58,10 @@ __all__ = [
     "CommandNotFoundError",
     "Config",
     "ConfigDict",
-    "extension_finder",
     "JITCompileError",
     "JITCompileFinder",
-    "module_config",
     "ResolvedConfig",
     "StubGenerationError",
+    "extension_finder",
+    "module_config",
 ]

--- a/src/charonload/_errors.py
+++ b/src/charonload/_errors.py
@@ -29,7 +29,7 @@ class JITCompileError(ABC, Exception):
 
         super().__init__(f"{self.step_name} failed:\n\n{self.log}" if log is not None else f"{self.step_name} failed.")
 
-    def __new__(cls: type[Self], *args: Any, **kwargs: Any) -> Self:  # noqa: ANN401, ARG003
+    def __new__(cls: type[Self], *args: Any, **kwargs: Any) -> Self:  # noqa: ANN401, ARG004
         if cls is JITCompileError:
             msg = f"Cannot instantiate abstract class {cls.__name__}"
             raise TypeError(msg)

--- a/src/charonload/_version.py
+++ b/src/charonload/_version.py
@@ -15,7 +15,7 @@ def _is_compatible(ver1: str, ver2: str) -> bool:
 def _str_to_tuple(ver: str) -> tuple[int, int, int]:
     components = list(map(int, ver.split(".")))
     components = [*components, 0, 0][:3]
-    return cast(tuple[int, int, int], tuple(components))
+    return cast("tuple[int, int, int]", tuple(components))
 
 
 def _same_minor_version(ver1: tuple[int, int, int], ver2: tuple[int, int, int]) -> bool:


### PR DESCRIPTION
A lot of time has passed since the last linter checks and ruff has received several larger updates containing new and updated rules. Address the warnings raised by these additional rules.