### PR TITLE
Upgrade CI images to latest version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
 
   publish:
     name: Upload release to GitHub Pages
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.event_name == 'release' && github.event.action == 'published'
 
     needs:
@@ -79,7 +79,7 @@ jobs:
       - publish
 
     name: "Check Docs"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: re-actors/alls-green@release/v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
         python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     name: "Python ${{ matrix.python }}"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
       - lint
 
     name: "Check Lint"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: re-actors/alls-green@release/v1

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   dist:
     name: Distribution build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
 
   publish-test:
     name: Upload release to TestPyPI
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.event_name == 'release' && github.event.action == 'published'
 
     needs:
@@ -53,7 +53,7 @@ jobs:
 
   publish:
     name: Upload release to PyPI
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.event_name == 'release' && github.event.action == 'published'
 
     needs:
@@ -83,7 +83,7 @@ jobs:
       - publish
 
     name: "Check PyPI"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: re-actors/alls-green@release/v1

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
       pull-requests: read
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: release-drafter/release-drafter@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04", "windows-2022"]
+        os: ["ubuntu-24.04", "windows-2025"]
         python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     name: "${{ matrix.os }} / Python ${{ matrix.python }}"
@@ -57,7 +57,7 @@ jobs:
       - tests
 
     name: "Check Tests"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: re-actors/alls-green@release/v1


### PR DESCRIPTION
The CI images for Ubuntu 24.04 and Windows 2025 are available for quite some time now. Upgrade to these to keep CI future-proof and test against more recent versions of our dependencies.