### PR TITLE
Support global configuration overrides with environment variables

### DIFF
--- a/src/charonload/_errors.py
+++ b/src/charonload/_errors.py
@@ -27,7 +27,25 @@ class JITCompileError(ABC, Exception):
         self.log = log
         """The full log from the underlying compiler."""
 
-        super().__init__(f"{self.step_name} failed:\n\n{self.log}" if log is not None else f"{self.step_name} failed.")
+        msg = ""
+        if self.log is not None:
+            msg += f"{self.step_name} failed:\n"
+            msg += "----------------------------------------------------------------\n"
+            msg += "\n"
+            msg += self.log
+            msg += "\n"
+            msg += "----------------------------------------------------------------\n"
+        else:
+            msg += f"{self.step_name} failed.\n"
+        msg += "\n"
+        msg += (
+            "charonload might automatically run a clean build on the next call in order to try to resolve the error. "
+        )
+        msg += "If the issue persists, you can override charonload's behavior via these environment variables:\n"
+        msg += "  - CHARONLOAD_FORCE_CLEAN_BUILD=1 : Enforce clean builds for all JIT compiled projects.\n"
+        msg += "  - CHARONLOAD_FORCE_VERBOSE=1     : Always show full JIT compilation logs (for debugging).\n"
+
+        super().__init__(msg)
 
     def __new__(cls: type[Self], *args: Any, **kwargs: Any) -> Self:  # noqa: ANN401, ARG004
         if cls is JITCompileError:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import multiprocessing
+import os
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -8,6 +10,18 @@ if TYPE_CHECKING:
 import pytest
 
 import charonload
+
+
+def _true_values() -> list[str]:
+    return ["1", "on", "On", "ON", "true", "TrUe", "True", "yes", "Yes", "YES", "y", "Y"]
+
+
+def _false_values() -> list[str]:
+    return ["0", "off", "Off", "OFF", "false", "FaLsE", "False", "no", "No", "NO", "n", "N"]
+
+
+def _error_values() -> list[str]:
+    return ["OOPS", "42", "f"]
 
 
 def test_provided_build_directory(shared_datadir: pathlib.Path, tmp_path: pathlib.Path) -> None:
@@ -80,6 +94,89 @@ def test_relative_build_directory(shared_datadir: pathlib.Path) -> None:
         )
 
     assert exc_info.type is ValueError
+
+
+def _force_clean_build(
+    shared_datadir: pathlib.Path,
+    environ_value: str,
+    value: bool,  # noqa: FBT001
+    expected_value: bool,  # noqa: FBT001
+) -> None:
+    os.environ["CHARONLOAD_FORCE_CLEAN_BUILD"] = environ_value
+
+    project_directory = shared_datadir / "torch_cpu"
+
+    module_config = charonload.ConfigDict()
+    module_config["test"] = charonload.Config(
+        project_directory,
+        clean_build=value,
+    )
+    config = module_config["test"]
+
+    assert config.clean_build == expected_value
+
+
+def _force_clean_build_error(shared_datadir: pathlib.Path, environ_value: str) -> None:
+    os.environ["CHARONLOAD_FORCE_CLEAN_BUILD"] = environ_value
+
+    project_directory = shared_datadir / "torch_cpu"
+
+    module_config = charonload.ConfigDict()
+    with pytest.raises(ValueError) as exc_info:
+        module_config["test"] = charonload.Config(
+            project_directory,
+        )
+
+    assert exc_info.type is ValueError
+
+
+@pytest.mark.parametrize("environ_value", _true_values())
+def test_force_clean_build_true(shared_datadir: pathlib.Path, environ_value: str) -> None:
+    p = multiprocessing.get_context("spawn").Process(
+        target=_force_clean_build,
+        args=(
+            shared_datadir,
+            environ_value,
+            False,
+            True,
+        ),
+    )
+
+    p.start()
+    p.join()
+    assert p.exitcode == 0
+
+
+@pytest.mark.parametrize("environ_value", _false_values())
+def test_force_clean_build_false(shared_datadir: pathlib.Path, environ_value: str) -> None:
+    p = multiprocessing.get_context("spawn").Process(
+        target=_force_clean_build,
+        args=(
+            shared_datadir,
+            environ_value,
+            True,
+            False,
+        ),
+    )
+
+    p.start()
+    p.join()
+    assert p.exitcode == 0
+
+
+@pytest.mark.parametrize("environ_value", _error_values())
+def test_force_clean_build_error(shared_datadir: pathlib.Path, environ_value: str) -> None:
+    p = multiprocessing.get_context("spawn").Process(
+        target=_force_clean_build_error,
+        args=(
+            shared_datadir,
+            environ_value,
+        ),
+    )
+
+    p.start()
+    p.join()
+    assert p.exitcode == 0
 
 
 def test_prohibited_cmake_option_configuration_types(shared_datadir: pathlib.Path) -> None:
@@ -218,3 +315,169 @@ def test_relative_stubs_directory(shared_datadir: pathlib.Path) -> None:
         )
 
     assert exc_info.type is ValueError
+
+
+def _force_stubs_invalid_ok(
+    shared_datadir: pathlib.Path,
+    environ_value: str,
+    value: bool,  # noqa: FBT001
+    expected_value: bool,  # noqa: FBT001
+) -> None:
+    os.environ["CHARONLOAD_FORCE_STUBS_INVALID_OK"] = environ_value
+
+    project_directory = shared_datadir / "torch_cpu"
+
+    module_config = charonload.ConfigDict()
+    module_config["test"] = charonload.Config(
+        project_directory,
+        stubs_invalid_ok=value,
+    )
+    config = module_config["test"]
+
+    assert config.stubs_invalid_ok == expected_value
+
+
+def _force_stubs_invalid_ok_error(shared_datadir: pathlib.Path, environ_value: str) -> None:
+    os.environ["CHARONLOAD_FORCE_STUBS_INVALID_OK"] = environ_value
+
+    project_directory = shared_datadir / "torch_cpu"
+
+    module_config = charonload.ConfigDict()
+    with pytest.raises(ValueError) as exc_info:
+        module_config["test"] = charonload.Config(
+            project_directory,
+        )
+
+    assert exc_info.type is ValueError
+
+
+@pytest.mark.parametrize("environ_value", _true_values())
+def test_force_stubs_invalid_ok_true(shared_datadir: pathlib.Path, environ_value: str) -> None:
+    p = multiprocessing.get_context("spawn").Process(
+        target=_force_stubs_invalid_ok,
+        args=(
+            shared_datadir,
+            environ_value,
+            False,
+            True,
+        ),
+    )
+
+    p.start()
+    p.join()
+    assert p.exitcode == 0
+
+
+@pytest.mark.parametrize("environ_value", _false_values())
+def test_force_stubs_invalid_ok_false(shared_datadir: pathlib.Path, environ_value: str) -> None:
+    p = multiprocessing.get_context("spawn").Process(
+        target=_force_stubs_invalid_ok,
+        args=(
+            shared_datadir,
+            environ_value,
+            True,
+            False,
+        ),
+    )
+
+    p.start()
+    p.join()
+    assert p.exitcode == 0
+
+
+@pytest.mark.parametrize("environ_value", _error_values())
+def test_force_stubs_invalid_ok_error(shared_datadir: pathlib.Path, environ_value: str) -> None:
+    p = multiprocessing.get_context("spawn").Process(
+        target=_force_stubs_invalid_ok_error,
+        args=(
+            shared_datadir,
+            environ_value,
+        ),
+    )
+
+    p.start()
+    p.join()
+    assert p.exitcode == 0
+
+
+def _force_verbose(
+    shared_datadir: pathlib.Path,
+    environ_value: str,
+    value: bool,  # noqa: FBT001
+    expected_value: bool,  # noqa: FBT001
+) -> None:
+    os.environ["CHARONLOAD_FORCE_VERBOSE"] = environ_value
+
+    project_directory = shared_datadir / "torch_cpu"
+
+    module_config = charonload.ConfigDict()
+    module_config["test"] = charonload.Config(
+        project_directory,
+        verbose=value,
+    )
+    config = module_config["test"]
+
+    assert config.verbose == expected_value
+
+
+def _force_verbose_error(shared_datadir: pathlib.Path, environ_value: str) -> None:
+    os.environ["CHARONLOAD_FORCE_VERBOSE"] = environ_value
+
+    project_directory = shared_datadir / "torch_cpu"
+
+    module_config = charonload.ConfigDict()
+    with pytest.raises(ValueError) as exc_info:
+        module_config["test"] = charonload.Config(
+            project_directory,
+        )
+
+    assert exc_info.type is ValueError
+
+
+@pytest.mark.parametrize("environ_value", _true_values())
+def test_force_verbose_true(shared_datadir: pathlib.Path, environ_value: str) -> None:
+    p = multiprocessing.get_context("spawn").Process(
+        target=_force_verbose,
+        args=(
+            shared_datadir,
+            environ_value,
+            False,
+            True,
+        ),
+    )
+
+    p.start()
+    p.join()
+    assert p.exitcode == 0
+
+
+@pytest.mark.parametrize("environ_value", _false_values())
+def test_force_verbose_false(shared_datadir: pathlib.Path, environ_value: str) -> None:
+    p = multiprocessing.get_context("spawn").Process(
+        target=_force_verbose,
+        args=(
+            shared_datadir,
+            environ_value,
+            True,
+            False,
+        ),
+    )
+
+    p.start()
+    p.join()
+    assert p.exitcode == 0
+
+
+@pytest.mark.parametrize("environ_value", _error_values())
+def test_force_verbose_error(shared_datadir: pathlib.Path, environ_value: str) -> None:
+    p = multiprocessing.get_context("spawn").Process(
+        target=_force_verbose_error,
+        args=(
+            shared_datadir,
+            environ_value,
+        ),
+    )
+
+    p.start()
+    p.join()
+    assert p.exitcode == 0


### PR DESCRIPTION
Although charonload provides the error logs when JIT compilation fails, simply actions to debug the issue like enabling verbose output or forcing a clean build requires users to edit the specified `Config` object. This may become a larger burden if this appears in an installed 3rd-party library that leverages charonload, meaning that the location of this configuration may be hidden in Python's package installation paths. Add support for overriding these common options via environment variables. To better guide users in such scenarios, provide some hints in the error logs about this mechanism.