### PR TITLE
Fix and suppress more ruff linter warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,10 +136,11 @@ typing-modules = ["charonload._compat.typing"]
     "D", # pydocstyle
 ]
 "tests/*" = [
-    "D",     # pydocstyle
-    "S101",  # assert-used
-    "INP",   # flake8-no-pep420
-    "PT011", # raises-too-broad
+    "D",       # pydocstyle
+    "S101",    # assert-used
+    "INP",     # flake8-no-pep420
+    "PT011",   # raises-too-broad
+    "PLC0415", # import-outside-top-level
 ]
 "docs/conf.py" = [
     "D100", # undocumented-public-module

--- a/src/charonload/_config.py
+++ b/src/charonload/_config.py
@@ -253,7 +253,7 @@ class ConfigDict(UserDict[str, ResolvedConfig]):
             verbose=self._str_to_bool(os.environ.get("CHARONLOAD_FORCE_VERBOSE", default=config.verbose)),
         )
 
-    def _str_to_bool(self: Self, s: str | bool) -> bool:
+    def _str_to_bool(self: Self, s: str | bool) -> bool:  # noqa: FBT001
         if isinstance(s, bool):
             return s
 

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -704,7 +704,7 @@ def test_torch_clean_build_compatible_version(shared_datadir: pathlib.Path, tmp_
     (build_directory / "charonload").mkdir(parents=True, exist_ok=True)
     dirty_file.touch()
     with (build_directory / "charonload" / "version.txt").open("w") as f:
-        f.write(".".join(charonload.__version__.split(".")[:-1] + ["9999"]))
+        f.write(".".join([*charonload.__version__.split(".")[:-1], "9999"]))
 
     assert dirty_file.exists()
 


### PR DESCRIPTION
In its recent release, ruff stabilized more rules that especially affect the unit tests. Suppress the `import-outside-top-level` rule as importing within the test function is essential and intended. Furthermore, fix the other appearing warnings.